### PR TITLE
chore: remove deprecated images and add new versions

### DIFF
--- a/common/fedora-cloud-40.pkr.hcl
+++ b/common/fedora-cloud-40.pkr.hcl
@@ -1,15 +1,15 @@
-source "openstack" "centos-8-stream" {
+source "openstack" "fedora-cloud-40" {
   flavor              = var.flavor
   networks            = var.networks
   security_groups     = var.security_groups
   floating_ip_network = var.floating_ip_network
   ssh_ip_version      = var.ssh_ip_version
-  ssh_username        = "centos"
+  ssh_username        = "fedora"
   image_visibility    = var.image_visibility
   image_tags          = var.image_tags
   config_drive        = var.config_drive
 
-  external_source_image_url    = "https://cloud.centos.org/centos/8-stream/x86_64/images/CentOS-Stream-GenericCloud-8-latest.x86_64.qcow2"
+  external_source_image_url    = "https://download.fedoraproject.org/pub/fedora/linux/releases/40/Cloud/x86_64/images/Fedora-Cloud-Base-Generic.x86_64-40-1.14.qcow2"
   external_source_image_format = "qcow2"
   external_source_image_properties = {
     hw_disk_bus   = "scsi"
@@ -21,10 +21,10 @@ source "openstack" "centos-8-stream" {
     hypervisor_type     = "qemu"
     vm_mode             = "hvm"
     os_type             = "linux"
-    os_distro           = "centos"
-    os_version          = "8-stream"
+    os_distro           = "fedora"
+    os_version          = "40"
     os_require_quiesce  = "yes"
-    os_admin_user       = "centos"
+    os_admin_user       = "fedora"
     hw_qemu_guest_agent = "yes"
     hw_vif_model        = "virtio"
     hw_disk_bus         = "scsi"

--- a/common/rocky-linux-9.pkr.hcl
+++ b/common/rocky-linux-9.pkr.hcl
@@ -1,15 +1,15 @@
-source "openstack" "fedora-cloud-38" {
+source "openstack" "rocky-linux-9" {
   flavor              = var.flavor
   networks            = var.networks
   security_groups     = var.security_groups
   floating_ip_network = var.floating_ip_network
   ssh_ip_version      = var.ssh_ip_version
-  ssh_username        = "fedora"
+  ssh_username        = "rocky"
   image_visibility    = var.image_visibility
   image_tags          = var.image_tags
   config_drive        = var.config_drive
 
-  external_source_image_url    = "https://ftp.halifax.rwth-aachen.de/fedora/linux/releases/38/Cloud/x86_64/images/Fedora-Cloud-Base-38-1.6.x86_64.qcow2"
+  external_source_image_url    = "https://dl.rockylinux.org/pub/rocky/9/images/x86_64/Rocky-9-GenericCloud-Base.latest.x86_64.qcow2"
   external_source_image_format = "qcow2"
   external_source_image_properties = {
     hw_disk_bus   = "scsi"
@@ -21,10 +21,10 @@ source "openstack" "fedora-cloud-38" {
     hypervisor_type     = "qemu"
     vm_mode             = "hvm"
     os_type             = "linux"
-    os_distro           = "fedora"
-    os_version          = "38"
+    os_distro           = "rocky"
+    os_version          = "9"
     os_require_quiesce  = "yes"
-    os_admin_user       = "fedora"
+    os_admin_user       = "rocky"
     hw_qemu_guest_agent = "yes"
     hw_vif_model        = "virtio"
     hw_disk_bus         = "scsi"

--- a/common/ubuntu-24_04.pkr.hcl
+++ b/common/ubuntu-24_04.pkr.hcl
@@ -1,0 +1,34 @@
+source "openstack" "ubuntu-24_04" {
+  flavor              = var.flavor
+  networks            = var.networks
+  security_groups     = var.security_groups
+  floating_ip_network = var.floating_ip_network
+  ssh_ip_version      = var.ssh_ip_version
+  ssh_username        = "ubuntu"
+  image_visibility    = var.image_visibility
+  image_tags          = var.image_tags
+  config_drive        = var.config_drive
+
+  external_source_image_url    = "https://cloud-images.ubuntu.com/noble/current/noble-server-cloudimg-amd64.img"
+  external_source_image_format = "qcow2"
+  external_source_image_properties = {
+    hw_disk_bus   = "scsi"
+    hw_scsi_model = "virtio-scsi"
+  }
+
+  metadata = {
+    architecture        = "x86_64"
+    hypervisor_type     = "qemu"
+    vm_mode             = "hvm"
+    os_type             = "linux"
+    os_distro           = "ubuntu"
+    os_version          = "24.04"
+    os_require_quiesce  = "yes"
+    os_admin_user       = "ubuntu"
+    hw_qemu_guest_agent = "yes"
+    hw_vif_model        = "virtio"
+    hw_disk_bus         = "scsi"
+    hw_scsi_model       = "virtio-scsi"
+    release             = "noble numbat"
+  }
+}

--- a/images/ansible/build.pkr.hcl
+++ b/images/ansible/build.pkr.hcl
@@ -1,8 +1,8 @@
 build {
   name = "ansible"
 
-  source "source.openstack.centos-8-stream" {
-    image_name = "${var.image_prefix}centos-8-stream-ansible"
+  source "source.openstack.rocky-linux-9" {
+    image_name = "${var.image_prefix}rocky-linux-9-ansible"
   }
   source "source.openstack.centos-9-stream" {
     image_name = "${var.image_prefix}centos-9-stream-ansible"
@@ -13,14 +13,17 @@ build {
   source "source.openstack.debian-12" {
     image_name = "${var.image_prefix}debian-12-ansible"
   }
-  source "source.openstack.fedora-cloud-38" {
-    image_name = "${var.image_prefix}fedora-cloud-38-ansible"
+  source "source.openstack.fedora-cloud-40" {
+    image_name = "${var.image_prefix}fedora-cloud-40-ansible"
   }
   source "source.openstack.ubuntu-20_04" {
     image_name = "${var.image_prefix}ubuntu-20.04-ansible"
   }
   source "source.openstack.ubuntu-22_04" {
     image_name = "${var.image_prefix}ubuntu-22.04-ansible"
+  }
+  source "source.openstack.ubuntu-24_04" {
+    image_name = "${var.image_prefix}ubuntu-24.04-ansible"
   }
 
   # wait for cloud-init
@@ -33,9 +36,9 @@ build {
   # upgrade and install base packages
   provisioner "shell" {
     only = [
-      "openstack.centos-8-stream",
+      "openstack.rocky-linux-9",
       "openstack.centos-9-stream",
-      "openstack.fedora-cloud-38",
+      "openstack.fedora-cloud-40",
     ]
     inline = [
       "sudo dnf update -y",
@@ -48,6 +51,7 @@ build {
       "openstack.debian-12",
       "openstack.ubuntu-20_04",
       "openstack.ubuntu-22_04",
+      "openstack.ubuntu-24_04",
     ]
     inline = [
       "echo 'debconf debconf/frontend select Noninteractive' | sudo debconf-set-selections",
@@ -60,6 +64,7 @@ build {
     only = [
       "openstack.ubuntu-20_04",
       "openstack.ubuntu-22_04",
+      "openstack.ubuntu-24_04",
     ]
     inline = [
       "sudo apt-get install -y software-properties-common",
@@ -79,6 +84,7 @@ build {
       "openstack.debian-12",
       "openstack.ubuntu-20_04",
       "openstack.ubuntu-22_04",
+      "openstack.ubuntu-24_04",
     ]
     inline = [
       "sudo apt-get install -y ansible-core",
@@ -92,6 +98,7 @@ build {
       "openstack.debian-12",
       "openstack.ubuntu-20_04",
       "openstack.ubuntu-22_04",
+      "openstack.ubuntu-24_04",
     ]
     inline = [
       "sudo apt-get install -y unattended-upgrades",
@@ -100,9 +107,9 @@ build {
   }
   provisioner "shell" {
     only = [
-      "openstack.centos-8-stream",
+      "openstack.rocky-linux-9",
       "openstack.centos-9-stream",
-      "openstack.fedora-cloud-38",
+      "openstack.fedora-cloud-40",
     ]
     inline = [
       "sudo dnf install -y dnf-automatic",
@@ -135,7 +142,7 @@ build {
   # empty resolv.conf - https://git.centos.org/centos/kickstarts/pull-request/12#
   provisioner "shell" {
     only = [
-      "openstack.centos-8-stream",
+      "openstack.rocky-linux-9",
       "openstack.centos-9-stream",
     ]
     inline = [
@@ -146,9 +153,9 @@ build {
   # cleaning for smaller image
   provisioner "shell" {
     only = [
-      "openstack.centos-8-stream",
+      "openstack.rocky-linux-9",
       "openstack.centos-9-stream",
-      "openstack.fedora-cloud-38",
+      "openstack.fedora-cloud-40",
     ]
     inline = [
       "sudo dnf autoremove -y && dnf clean all && sudo rm -rf /var/cache/yum",
@@ -160,6 +167,7 @@ build {
       "openstack.debian-12",
       "openstack.ubuntu-20_04",
       "openstack.ubuntu-22_04",
+      "openstack.ubuntu-24_04",
     ]
     inline = [
       "sudo apt-get autoclean",

--- a/images/ansible/centos-8-stream.pkr.hcl
+++ b/images/ansible/centos-8-stream.pkr.hcl
@@ -1,1 +1,0 @@
-../../common/centos-8-stream.pkr.hcl

--- a/images/ansible/fedora-cloud-38.pkr.hcl
+++ b/images/ansible/fedora-cloud-38.pkr.hcl
@@ -1,1 +1,0 @@
-../../common/fedora-cloud-38.pkr.hcl

--- a/images/ansible/fedora-cloud-40.pkr.hcl
+++ b/images/ansible/fedora-cloud-40.pkr.hcl
@@ -1,0 +1,1 @@
+../../common/fedora-cloud-40.pkr.hcl

--- a/images/ansible/rocky-linux-9.pkr.hcl
+++ b/images/ansible/rocky-linux-9.pkr.hcl
@@ -1,0 +1,1 @@
+../../common/rocky-linux-9.pkr.hcl

--- a/images/ansible/ubuntu-24_04.pkr.hcl
+++ b/images/ansible/ubuntu-24_04.pkr.hcl
@@ -1,0 +1,1 @@
+../../common/ubuntu-24_04.pkr.hcl


### PR DESCRIPTION
Removes:
- fedora-cloud-38
- centos-8-stream

Adds:
- fedora-cloud-40
- rocky-linux-9
- ubuntu-24_04